### PR TITLE
[Feature/#10] 회원 로그인 기능 개발

### DIFF
--- a/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberController.java
@@ -2,7 +2,6 @@ package com.sprios.sprios_spring.domain.member.controller;
 
 import com.sprios.sprios_spring.domain.member.dto.LoginRequest;
 import com.sprios.sprios_spring.domain.member.dto.MemberDto;
-import com.sprios.sprios_spring.domain.member.entity.Member;
 import com.sprios.sprios_spring.domain.member.exception.MemberDuplicatedException;
 import com.sprios.sprios_spring.domain.member.exception.MemberNotFoundException;
 import com.sprios.sprios_spring.domain.member.service.MemberService;
@@ -35,8 +34,7 @@ public class MemberController {
     if (memberService.isDuplicatedAccount(memberDto.getAccount())) {
       throw new MemberDuplicatedException();
     }
-    Member member = MemberDto.toEntity(memberDto, passwordEncoder);
-    memberService.registrationMember(member);
+    memberService.registrationMember(memberDto);
     return ResponseEntity.ok(ResultResponse.of(MEMBER_REGISTRATION_SUCCESS));
   }
 

--- a/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberController.java
@@ -2,9 +2,13 @@ package com.sprios.sprios_spring.domain.member.controller;
 
 import com.sprios.sprios_spring.domain.member.dto.LoginRequest;
 import com.sprios.sprios_spring.domain.member.dto.MemberRegistrationRequest;
+import com.sprios.sprios_spring.domain.member.entity.Member;
 import com.sprios.sprios_spring.domain.member.exception.MemberDuplicatedException;
 import com.sprios.sprios_spring.domain.member.exception.MemberNotFoundException;
+import com.sprios.sprios_spring.domain.member.service.LoginService;
 import com.sprios.sprios_spring.domain.member.service.MemberService;
+import com.sprios.sprios_spring.global.annotation.LoginMember;
+import com.sprios.sprios_spring.global.annotation.LoginRequired;
 import com.sprios.sprios_spring.global.result.ResultResponse;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +30,7 @@ public class MemberController {
   public static final String MEMBER_API_URI = "/api/members";
 
   private final MemberService memberService;
+  private final LoginService loginService;
 
   @PostMapping
   public ResponseEntity<ResultResponse> registration(
@@ -52,8 +57,22 @@ public class MemberController {
     boolean isValidMember = memberService.isValidMember(loginRequest);
 
     if (isValidMember) {
+      loginService.login(memberService.findMemberByAccount(loginRequest.getAccount()).getId());
       return ResponseEntity.ok(ResultResponse.of(MEMBER_LOGIN_SUCCESS));
     }
     throw new MemberNotFoundException();
+  }
+
+  @LoginRequired
+  @GetMapping("/logout")
+  public ResponseEntity<ResultResponse> logout() {
+    loginService.logout();
+    return ResponseEntity.ok(ResultResponse.of(MEMBER_LOGOUT_SUCCESS));
+  }
+
+  @LoginRequired
+  @GetMapping("/info")
+  public ResponseEntity<Member> getMemberInfo(@LoginMember Member member) {
+    return ResponseEntity.ok(member);
   }
 }

--- a/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberController.java
@@ -1,7 +1,7 @@
 package com.sprios.sprios_spring.domain.member.controller;
 
 import com.sprios.sprios_spring.domain.member.dto.LoginRequest;
-import com.sprios.sprios_spring.domain.member.dto.MemberDto;
+import com.sprios.sprios_spring.domain.member.dto.MemberRegistrationRequest;
 import com.sprios.sprios_spring.domain.member.exception.MemberDuplicatedException;
 import com.sprios.sprios_spring.domain.member.exception.MemberNotFoundException;
 import com.sprios.sprios_spring.domain.member.service.MemberService;
@@ -10,7 +10,6 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -27,14 +26,14 @@ public class MemberController {
   public static final String MEMBER_API_URI = "/api/members";
 
   private final MemberService memberService;
-  private final PasswordEncoder passwordEncoder;
 
   @PostMapping
-  public ResponseEntity<ResultResponse> registration(@RequestBody @Valid MemberDto memberDto) {
-    if (memberService.isDuplicatedAccount(memberDto.getAccount())) {
+  public ResponseEntity<ResultResponse> registration(
+      @RequestBody @Valid MemberRegistrationRequest memberRegistrationRequest) {
+    if (memberService.isDuplicatedAccount(memberRegistrationRequest.getAccount())) {
       throw new MemberDuplicatedException();
     }
-    memberService.registrationMember(memberDto);
+    memberService.registrationMember(memberRegistrationRequest);
     return ResponseEntity.ok(ResultResponse.of(MEMBER_REGISTRATION_SUCCESS));
   }
 
@@ -50,7 +49,7 @@ public class MemberController {
 
   @PostMapping("/login")
   public ResponseEntity<ResultResponse> login(@RequestBody @Valid LoginRequest loginRequest) {
-    boolean isValidMember = memberService.isValidMember(loginRequest, passwordEncoder);
+    boolean isValidMember = memberService.isValidMember(loginRequest);
 
     if (isValidMember) {
       return ResponseEntity.ok(ResultResponse.of(MEMBER_LOGIN_SUCCESS));

--- a/src/main/java/com/sprios/sprios_spring/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/dto/MemberDto.java
@@ -1,12 +1,9 @@
 package com.sprios.sprios_spring.domain.member.dto;
 
 import com.sprios.sprios_spring.domain.member.entity.Gender;
-import com.sprios.sprios_spring.domain.member.entity.Member;
 import lombok.*;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.validation.constraints.Email;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
 
 @Getter
@@ -34,17 +31,4 @@ public class MemberDto {
   private String phone;
   private String profileImageUrl;
   private String introduce;
-
-  public static Member toEntity(MemberDto memberDto, PasswordEncoder passwordEncoder) {
-    return Member.builder()
-        .account(memberDto.getAccount())
-        .password(passwordEncoder.encode(memberDto.getPassword()))
-        .name(memberDto.getName())
-        .gender(memberDto.getGender())
-        .email(memberDto.getEmail())
-        .phone(memberDto.getPhone())
-        .profileImageUrl(memberDto.getProfileImageUrl())
-        .introduce(memberDto.getIntroduce())
-        .build();
-  }
 }

--- a/src/main/java/com/sprios/sprios_spring/domain/member/dto/MemberRegistrationRequest.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/dto/MemberRegistrationRequest.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.Pattern;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberDto {
+public class MemberRegistrationRequest {
 
   private String account;
 

--- a/src/main/java/com/sprios/sprios_spring/domain/member/entity/Member.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/entity/Member.java
@@ -67,4 +67,8 @@ public class Member extends BaseEntity {
     this.profileImageUrl = profileImageUrl;
     this.introduce = introduce;
   }
+
+  public void setEncryptedPassword(String encryptedPassword) {
+    this.password = encryptedPassword;
+  }
 }

--- a/src/main/java/com/sprios/sprios_spring/domain/member/exception/UnAuthorizedAccessException.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/exception/UnAuthorizedAccessException.java
@@ -4,7 +4,7 @@ import com.sprios.sprios_spring.global.error.ErrorCode;
 import com.sprios.sprios_spring.global.error.exception.BusinessException;
 
 public class UnAuthorizedAccessException extends BusinessException {
-    public UnAuthorizedAccessException() {
-        super(ErrorCode.UN_AUTHORIZED_ACCESS);
-    }
+  public UnAuthorizedAccessException() {
+    super(ErrorCode.UN_AUTHORIZED_ACCESS);
+  }
 }

--- a/src/main/java/com/sprios/sprios_spring/domain/member/exception/UnAuthorizedAccessException.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/exception/UnAuthorizedAccessException.java
@@ -1,0 +1,10 @@
+package com.sprios.sprios_spring.domain.member.exception;
+
+import com.sprios.sprios_spring.global.error.ErrorCode;
+import com.sprios.sprios_spring.global.error.exception.BusinessException;
+
+public class UnAuthorizedAccessException extends BusinessException {
+    public UnAuthorizedAccessException() {
+        super(ErrorCode.UN_AUTHORIZED_ACCESS);
+    }
+}

--- a/src/main/java/com/sprios/sprios_spring/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/mapper/MemberMapper.java
@@ -1,0 +1,19 @@
+package com.sprios.sprios_spring.domain.member.mapper;
+
+import com.sprios.sprios_spring.domain.member.dto.MemberDto;
+import com.sprios.sprios_spring.domain.member.entity.Member;
+
+public class MemberMapper {
+    public static Member toEntity(MemberDto memberDto) {
+        return Member.builder()
+                .account(memberDto.getAccount())
+                .password(memberDto.getPassword())
+                .name(memberDto.getName())
+                .gender(memberDto.getGender())
+                .email(memberDto.getEmail())
+                .phone(memberDto.getPhone())
+                .profileImageUrl(memberDto.getProfileImageUrl())
+                .introduce(memberDto.getIntroduce())
+                .build();
+    }
+}

--- a/src/main/java/com/sprios/sprios_spring/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/mapper/MemberMapper.java
@@ -1,19 +1,19 @@
 package com.sprios.sprios_spring.domain.member.mapper;
 
-import com.sprios.sprios_spring.domain.member.dto.MemberDto;
+import com.sprios.sprios_spring.domain.member.dto.MemberRegistrationRequest;
 import com.sprios.sprios_spring.domain.member.entity.Member;
 
 public class MemberMapper {
-    public static Member toEntity(MemberDto memberDto) {
-        return Member.builder()
-                .account(memberDto.getAccount())
-                .password(memberDto.getPassword())
-                .name(memberDto.getName())
-                .gender(memberDto.getGender())
-                .email(memberDto.getEmail())
-                .phone(memberDto.getPhone())
-                .profileImageUrl(memberDto.getProfileImageUrl())
-                .introduce(memberDto.getIntroduce())
-                .build();
-    }
+  public static Member toEntity(MemberRegistrationRequest memberRegistrationRequest) {
+    return Member.builder()
+        .account(memberRegistrationRequest.getAccount())
+        .password(memberRegistrationRequest.getPassword())
+        .name(memberRegistrationRequest.getName())
+        .gender(memberRegistrationRequest.getGender())
+        .email(memberRegistrationRequest.getEmail())
+        .phone(memberRegistrationRequest.getPhone())
+        .profileImageUrl(memberRegistrationRequest.getProfileImageUrl())
+        .introduce(memberRegistrationRequest.getIntroduce())
+        .build();
+  }
 }

--- a/src/main/java/com/sprios/sprios_spring/domain/member/service/LoginService.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/service/LoginService.java
@@ -12,7 +12,7 @@ import javax.servlet.http.HttpSession;
 public class LoginService {
   private final HttpSession httpSession;
   private final MemberService memberService;
-  public static final String MEMBER_ID = "MEMBER_ID";
+  private static final String MEMBER_ID = "MEMBER_ID";
 
   public void login(long id) {
     httpSession.setAttribute(MEMBER_ID, id);

--- a/src/main/java/com/sprios/sprios_spring/domain/member/service/LoginService.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/service/LoginService.java
@@ -1,0 +1,33 @@
+package com.sprios.sprios_spring.domain.member.service;
+
+import com.sprios.sprios_spring.domain.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpSession;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginService {
+  private final HttpSession httpSession;
+  private final MemberService memberService;
+  public static final String MEMBER_ID = "MEMBER_ID";
+
+  public void login(long id) {
+    httpSession.setAttribute(MEMBER_ID, id);
+  }
+
+  public void logout() {
+    httpSession.removeAttribute(MEMBER_ID);
+  }
+
+  public Member getLoginMember() {
+    Long memberId = (Long) httpSession.getAttribute(MEMBER_ID);
+    return memberService.findMemberById(memberId);
+  }
+
+  public Long getLoginMemberId() {
+    return (Long) httpSession.getAttribute(MEMBER_ID);
+  }
+}

--- a/src/main/java/com/sprios/sprios_spring/domain/member/service/MemberService.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/service/MemberService.java
@@ -18,7 +18,6 @@ public class MemberService {
   private final MemberRepository memberRepository;
   private final PasswordUtil passwordUtil;
 
-  @Transactional
   public void registrationMember(MemberRegistrationRequest memberRegistrationRequest) {
     Member member = MemberMapper.toEntity(memberRegistrationRequest);
     member.setEncryptedPassword(passwordUtil.encodingPassword(member.getPassword()));

--- a/src/main/java/com/sprios/sprios_spring/domain/member/service/MemberService.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.sprios.sprios_spring.domain.member.service;
 
 import com.sprios.sprios_spring.domain.member.dto.LoginRequest;
 import com.sprios.sprios_spring.domain.member.dto.MemberDto;
+import com.sprios.sprios_spring.domain.member.mapper.MemberMapper;
 import com.sprios.sprios_spring.domain.member.entity.Member;
 import com.sprios.sprios_spring.domain.member.exception.MemberNotFoundException;
 import com.sprios.sprios_spring.domain.member.repository.MemberRepository;
@@ -18,7 +19,9 @@ public class MemberService {
 
   // Member 등록
   @Transactional
-  public void registrationMember(Member member) {
+  public void registrationMember(MemberDto memberDto) {
+    Member member = MemberMapper.toEntity(memberDto);
+    // 비밀번호 암호화
     memberRepository.save(member);
   }
 

--- a/src/main/java/com/sprios/sprios_spring/domain/member/service/MemberService.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/service/MemberService.java
@@ -1,14 +1,14 @@
 package com.sprios.sprios_spring.domain.member.service;
 
 import com.sprios.sprios_spring.domain.member.dto.LoginRequest;
-import com.sprios.sprios_spring.domain.member.dto.MemberDto;
+import com.sprios.sprios_spring.domain.member.dto.MemberRegistrationRequest;
 import com.sprios.sprios_spring.domain.member.mapper.MemberMapper;
 import com.sprios.sprios_spring.domain.member.entity.Member;
 import com.sprios.sprios_spring.domain.member.exception.MemberNotFoundException;
 import com.sprios.sprios_spring.domain.member.repository.MemberRepository;
+import com.sprios.sprios_spring.global.util.PasswordUtil;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,12 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberService {
   private final MemberRepository memberRepository;
+  private final PasswordUtil passwordUtil;
 
-  // Member 등록
   @Transactional
-  public void registrationMember(MemberDto memberDto) {
-    Member member = MemberMapper.toEntity(memberDto);
-    // 비밀번호 암호화
+  public void registrationMember(MemberRegistrationRequest memberRegistrationRequest) {
+    Member member = MemberMapper.toEntity(memberRegistrationRequest);
+    member.setEncryptedPassword(passwordUtil.encodingPassword(member.getPassword()));
     memberRepository.save(member);
   }
 
@@ -37,11 +37,9 @@ public class MemberService {
     return memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
   }
 
-  // 회원 정보가 유효한지 확인
-  public boolean isValidMember(LoginRequest loginRequest, PasswordEncoder passwordEncoder) {
+  public boolean isValidMember(LoginRequest loginRequest) {
     Member member = findMemberByAccount(loginRequest.getAccount());
-    // DTO로 전달된 비밀번호와 DB에 저장된 암호화된 비밀번호가 같은지 확인
-    if (passwordEncoder.matches(loginRequest.getPassword(), member.getPassword())) {
+    if (passwordUtil.isSamePassword(loginRequest.getPassword(), member.getPassword())) {
       return true;
     }
     return false;

--- a/src/main/java/com/sprios/sprios_spring/global/annotation/LoginMember.java
+++ b/src/main/java/com/sprios/sprios_spring/global/annotation/LoginMember.java
@@ -1,0 +1,9 @@
+package com.sprios.sprios_spring.global.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+/** 로그인 된 사용자 정보를 바인딩 해주는 어노테이션 */
+public @interface LoginMember {}

--- a/src/main/java/com/sprios/sprios_spring/global/annotation/LoginRequired.java
+++ b/src/main/java/com/sprios/sprios_spring/global/annotation/LoginRequired.java
@@ -1,0 +1,9 @@
+package com.sprios.sprios_spring.global.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+/** 로그인 상태인지 체크해주는 어노테이션 */
+public @interface LoginRequired {}

--- a/src/main/java/com/sprios/sprios_spring/global/config/WebConfig.java
+++ b/src/main/java/com/sprios/sprios_spring/global/config/WebConfig.java
@@ -1,0 +1,28 @@
+package com.sprios.sprios_spring.global.config;
+
+import com.sprios.sprios_spring.global.interceptor.LoginInterceptor;
+import com.sprios.sprios_spring.global.resolver.LoginMemberArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+  private final LoginInterceptor loginInterceptor;
+  private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(loginInterceptor);
+  }
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(loginMemberArgumentResolver);
+  }
+}

--- a/src/main/java/com/sprios/sprios_spring/global/error/ErrorCode.java
+++ b/src/main/java/com/sprios/sprios_spring/global/error/ErrorCode.java
@@ -14,7 +14,7 @@ public enum ErrorCode {
   // MemberDomain 도메인
   MEMBER_NOT_FOUND(400, "M001", "회원 찾기 실패"),
   MEMBER_ACCOUNT_DUPLICATED(400, "M002", "회원 아이디 중복"),
-  ;
+  UN_AUTHORIZED_ACCESS(400, "M003", "승인되지 않은 접근");
 
   private final int status;
   private final String code;

--- a/src/main/java/com/sprios/sprios_spring/global/interceptor/LoginInterceptor.java
+++ b/src/main/java/com/sprios/sprios_spring/global/interceptor/LoginInterceptor.java
@@ -1,0 +1,36 @@
+package com.sprios.sprios_spring.global.interceptor;
+
+import com.sprios.sprios_spring.domain.member.exception.UnAuthorizedAccessException;
+import com.sprios.sprios_spring.domain.member.service.LoginService;
+import com.sprios.sprios_spring.global.annotation.LoginRequired;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+@RequiredArgsConstructor
+// 인터셉터를 통해 로그인 처리 구현
+public class LoginInterceptor implements HandlerInterceptor {
+
+  private final LoginService loginService;
+
+  @Override
+  // 컨트롤러가 호출되기 전에 실행됨
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+      throws UnAuthorizedAccessException {
+    // HandlerMethod: @RequestMapping과 그 하위 어노테이션(@GetMapping 등)이 붙은 메소드의 정보를 추상화한 객체
+    // 즉 handler가 매핑된 메소드의 정보고, 그 메소드의 어노테이션에 LoginRequired가 있으면 실행
+    if (handler instanceof HandlerMethod
+        && ((HandlerMethod) handler).hasMethodAnnotation(LoginRequired.class)) {
+      Long memberId = loginService.getLoginMemberId();
+      if (memberId == null) {
+        throw new UnAuthorizedAccessException();
+      }
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/sprios/sprios_spring/global/resolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/sprios/sprios_spring/global/resolver/LoginMemberArgumentResolver.java
@@ -1,0 +1,37 @@
+package com.sprios.sprios_spring.global.resolver;
+
+import com.sprios.sprios_spring.domain.member.service.LoginService;
+import com.sprios.sprios_spring.global.annotation.LoginMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+// 파라미터가 있을 때 원하는 값을 바인딩해주는 인터페이스
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+  private final LoginService loginService;
+
+  @Override
+  // 현재 파라미터를 resolver가 지원하는지에 대한 boolean 리턴
+  public boolean supportsParameter(MethodParameter methodParameter) {
+    // 메소드의 파라미터가 LoginMember 어노테이션을 달고 있으면 resolver의 지원 대상이됨
+    return methodParameter.hasParameterAnnotation(LoginMember.class);
+  }
+
+  @Override
+  // 실제로 바인딩 할 객체를 return함
+  public Object resolveArgument(
+      MethodParameter methodParameter,
+      ModelAndViewContainer modelAndViewContainer,
+      NativeWebRequest nativeWebRequest,
+      WebDataBinderFactory webDataBinderFactory)
+      throws Exception {
+    return loginService.getLoginMember();
+  }
+}

--- a/src/main/java/com/sprios/sprios_spring/global/result/ResultCode.java
+++ b/src/main/java/com/sprios/sprios_spring/global/result/ResultCode.java
@@ -14,6 +14,7 @@ public enum ResultCode {
   MEMBER_ACCOUNT_DUPLICATED("M002", "회원 아이디 중복"),
   MEMBER_ACCOUNT_NOT_DUPLICATED("M003", "회원 아이디 중복되지않음"),
   MEMBER_LOGIN_SUCCESS("M004", "회원 로그인 성공"),
+  MEMBER_LOGOUT_SUCCESS("M005", "회원 로그아웃 성공"),
   ;
 
   private final String code;

--- a/src/main/java/com/sprios/sprios_spring/global/result/ResultResponse.java
+++ b/src/main/java/com/sprios/sprios_spring/global/result/ResultResponse.java
@@ -17,7 +17,7 @@ public class ResultResponse {
     return new ResultResponse(resultCode, "");
   }
 
-  public ResultResponse(ResultCode resultCode, Object data) {
+  private ResultResponse(ResultCode resultCode, Object data) {
     this.code = resultCode.getCode();
     this.message = resultCode.getMessage();
     this.data = data;

--- a/src/main/java/com/sprios/sprios_spring/global/util/PasswordUtil.java
+++ b/src/main/java/com/sprios/sprios_spring/global/util/PasswordUtil.java
@@ -1,0 +1,19 @@
+package com.sprios.sprios_spring.global.util;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class PasswordUtil {
+    private final PasswordEncoder passwordEncoder;
+    public String encodingPassword(String password) {
+        return passwordEncoder.encode(password);
+    }
+
+    public boolean isSamePassword(String rowPassword, String encryptPassword) {
+        return passwordEncoder.matches(rowPassword, encryptPassword);
+    }
+}


### PR DESCRIPTION
# 추가 및 변경된 기능
- mapper 클래스를 따로 만들어서 dto와 mapper 분리
- 비밀번호 암호화 및 비교를 담당하는 util 클래스 생성
- 세션에 회원의 아이디 저장, 이를 이용하여 로그인, 로그아웃 구현
- Interceptor를 통해서 @LoginRequired 어노테이션 이 붙은 api는 로그인 상태에서만 호출 가능 하도록 설정
- ArgumentResolver를 통해서 @LoginMember 어노테이션이 파라미터에는 로그인되어있는 Member의 정보를 바인딩하도록 설정
- 이를 통해서 로그인, 로그아웃, 로그인된 회원정보 조회 api 구현

로그인 api
<img width="447" alt="image" src="https://user-images.githubusercontent.com/108508730/206274206-849c7a7a-3897-4b20-b2dc-0301a4831c45.png">
<img width="333" alt="image" src="https://user-images.githubusercontent.com/108508730/206274271-4799edbc-920a-4443-b4bd-42a69cb7e2b5.png">

로그인 상태에서 로그인된 유저 정보 조회
<img width="669" alt="image" src="https://user-images.githubusercontent.com/108508730/206274408-ee72ca3e-57cb-4713-8b3f-ad54e87e67b7.png">

로그인 안된 상태에서 유저 정보 조회
<img width="444" alt="image" src="https://user-images.githubusercontent.com/108508730/206274752-d99fac18-5953-4462-a04e-58ff7cc46f6f.png">

로그아웃 api
<img width="353" alt="image" src="https://user-images.githubusercontent.com/108508730/206274885-fb3857d0-e815-4cd3-bc6c-7118170263b2.png">
