### PR TITLE
[feature/#15] 스터디들을 페이징기법을 이용해서 조회하는 API 구현

### DIFF
--- a/src/main/java/com/sprios/sprios_spring/domain/post/controller/PostController.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/post/controller/PostController.java
@@ -9,6 +9,8 @@ import com.sprios.sprios_spring.global.annotation.LoginRequired;
 import com.sprios.sprios_spring.global.result.ResultResponse;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -45,5 +47,14 @@ public class PostController {
   public ResponseEntity<ResultResponse> getMemberPostList(@RequestParam Long id) {
     List<PostInfoResponse> postInfoResponseList = postService.getPostListByWriterId(id);
     return ResponseEntity.ok(ResultResponse.of(WRITER_POST_GET_SUCCESS, postInfoResponseList));
+  }
+
+  @GetMapping("/page/{page}")
+  public ResponseEntity<ResultResponse> getPostListWithPaging(
+      @PathVariable Integer page, @RequestParam(defaultValue = "10") Integer size) {
+    PageRequest pageRequest = PageRequest.of(page, size);
+    Page<PostInfoResponse> postInfoResponseList = postService.getPostListWithPaging(pageRequest);
+    return ResponseEntity.ok(
+        ResultResponse.of(POST_PAGING_GET_SUCCESS, postInfoResponseList.getContent()));
   }
 }

--- a/src/main/java/com/sprios/sprios_spring/domain/post/mapper/PostMapper.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/post/mapper/PostMapper.java
@@ -5,6 +5,7 @@ import com.sprios.sprios_spring.domain.member.mapper.MemberMapper;
 import com.sprios.sprios_spring.domain.post.dto.PostCreateRequest;
 import com.sprios.sprios_spring.domain.post.dto.PostInfoResponse;
 import com.sprios.sprios_spring.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -28,5 +29,9 @@ public class PostMapper {
 
   public List<PostInfoResponse> toDtoList(List<Post> posts) {
     return posts.stream().map(this::toDto).collect(Collectors.toList());
+  }
+
+  public Page<PostInfoResponse> toDtoList(Page<Post> postList){
+    return postList.map(this::toDto);
   }
 }

--- a/src/main/java/com/sprios/sprios_spring/domain/post/service/PostService.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/post/service/PostService.java
@@ -15,6 +15,8 @@ import com.sprios.sprios_spring.global.util.ImageUtil;
 import com.sprios.sprios_spring.global.vo.Image;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -53,5 +55,10 @@ public class PostService {
   public PostInfoResponse getPostById(Long postId) {
     Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
     return postMapper.toDto(post);
+  }
+
+  public Page<PostInfoResponse> getPostListWithPaging(PageRequest pageRequest) {
+    Page<Post> postPages = postRepository.findAll(pageRequest);
+    return postMapper.toDtoList(postPages);
   }
 }

--- a/src/main/java/com/sprios/sprios_spring/global/result/ResultCode.java
+++ b/src/main/java/com/sprios/sprios_spring/global/result/ResultCode.java
@@ -22,6 +22,7 @@ public enum ResultCode {
   POST_CREATE_SUCCESS("P001", "게시물 생성 성공"),
   POST_GET_SUCCESS("P002", "게시물 조회 성공"),
   WRITER_POST_GET_SUCCESS("P003", "작성자의 게시물들 조회 성공"),
+  POST_PAGING_GET_SUCCESS("P004", "게시물들 페이징 조회 성공"),
   ;
 
   private final String code;


### PR DESCRIPTION
http://localhost:8080/api/posts/page/0?size=3
이런식으로 호출하면 전체 게시물 중 사이즈를 3씩 쪼개서 0번 페이지를 조회하겠다는 뜻입니다.
```json
{
    "code": "P004",
    "message": "게시물들 페이징 조회 성공",
    "data": [
        {
            "content": "-----3-----",
            "memberPostInfoResponse": {
                "id": 1,
                "account": "deca3248",
                "imageUrl": "https://identitylessimgserver.s3.ap-northeast-2.amazonaws.com/member/base_profile.png"
            },
            "imageUrls": [
                "https://identitylessimgserver.s3.ap-northeast-2.amazonaws.com/post/%E1%84%89%E1%85%B3%E1%84%91%E1%85%B3%E1%84%85%E1%85%B5%E1%86%BC.png"
            ],
            "likeCount": 0,
            "createdAt": [
                2022,
                12,
                23,
                16,
                13,
                40,
                740491000
            ]
        }
    ]
}
```
이런식으로 게시물 데이터의 배열이 응답값으로 오게됩니다