### PR TITLE
[Feature/#19] 회원 프로필 정보 업데이트 기능구현

### DIFF
--- a/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberUpdateController.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberUpdateController.java
@@ -28,6 +28,6 @@ public class MemberUpdateController {
       @RequestPart (value = "image", required = false) MultipartFile uploadImage,
       @RequestPart (value = "memberUpdateProfileRequest") MemberUpdateProfileRequest memberUpdateProfileRequest) {
     memberUpdateService.updateMemberProfile(uploadImage, memberUpdateProfileRequest);
-    return ResponseEntity.ok(ResultResponse.of(ResultCode.MEMBER_IMAGEUPDATE_SUCCESS, true));
+    return ResponseEntity.ok(ResultResponse.of(ResultCode.MEMBER_UPDATE_SUCCESS, true));
   }
 }

--- a/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberUpdateController.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberUpdateController.java
@@ -1,5 +1,6 @@
 package com.sprios.sprios_spring.domain.member.controller;
 
+import com.sprios.sprios_spring.domain.member.dto.MemberUpdateProfileRequest;
 import com.sprios.sprios_spring.domain.member.service.MemberUpdateService;
 import com.sprios.sprios_spring.global.result.ResultCode;
 import com.sprios.sprios_spring.global.result.ResultResponse;
@@ -7,10 +8,7 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import static com.sprios.sprios_spring.domain.member.controller.MemberUpdateController.MEMBER_API_URI;
@@ -23,9 +21,10 @@ public class MemberUpdateController {
   public static final String MEMBER_API_URI = "/api/member/update";
   private final MemberUpdateService memberUpdateService;
 
-  @PostMapping("/img")
-  public ResponseEntity<ResultResponse> uploadImage(@RequestParam MultipartFile uploadImage) {
-    memberUpdateService.uploadImgS3(uploadImage);
+  @PostMapping
+  public ResponseEntity<ResultResponse> uploadImage(@RequestParam MultipartFile uploadImage,
+                                                    @RequestBody MemberUpdateProfileRequest memberUpdateProfileRequest) {
+    memberUpdateService.updateMemberProfile(uploadImage, memberUpdateProfileRequest);
     return ResponseEntity.ok(ResultResponse.of(ResultCode.MEMBER_IMAGEUPDATE_SUCCESS, true));
   }
 }

--- a/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberUpdateController.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberUpdateController.java
@@ -2,6 +2,7 @@ package com.sprios.sprios_spring.domain.member.controller;
 
 import com.sprios.sprios_spring.domain.member.dto.MemberUpdateProfileRequest;
 import com.sprios.sprios_spring.domain.member.service.MemberUpdateService;
+import com.sprios.sprios_spring.global.annotation.LoginRequired;
 import com.sprios.sprios_spring.global.result.ResultCode;
 import com.sprios.sprios_spring.global.result.ResultResponse;
 import lombok.AccessLevel;
@@ -21,6 +22,7 @@ public class MemberUpdateController {
   public static final String MEMBER_API_URI = "/api/member/update";
   private final MemberUpdateService memberUpdateService;
 
+  @LoginRequired
   @PostMapping
   public ResponseEntity<ResultResponse> updateMember(@RequestParam MultipartFile uploadImage,
                                                     @RequestBody MemberUpdateProfileRequest memberUpdateProfileRequest) {

--- a/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberUpdateController.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberUpdateController.java
@@ -19,11 +19,11 @@ import static com.sprios.sprios_spring.domain.member.controller.MemberUpdateCont
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @RequestMapping(MEMBER_API_URI)
 public class MemberUpdateController {
-  public static final String MEMBER_API_URI = "/api/member/update";
+  public static final String MEMBER_API_URI = "/api/members";
   private final MemberUpdateService memberUpdateService;
 
   @LoginRequired
-  @PostMapping
+  @PostMapping("/update")
   public ResponseEntity<ResultResponse> updateMember(@RequestParam MultipartFile uploadImage,
                                                     @RequestBody MemberUpdateProfileRequest memberUpdateProfileRequest) {
     memberUpdateService.updateMemberProfile(uploadImage, memberUpdateProfileRequest);

--- a/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberUpdateController.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberUpdateController.java
@@ -22,7 +22,7 @@ public class MemberUpdateController {
   private final MemberUpdateService memberUpdateService;
 
   @PostMapping
-  public ResponseEntity<ResultResponse> uploadImage(@RequestParam MultipartFile uploadImage,
+  public ResponseEntity<ResultResponse> updateMember(@RequestParam MultipartFile uploadImage,
                                                     @RequestBody MemberUpdateProfileRequest memberUpdateProfileRequest) {
     memberUpdateService.updateMemberProfile(uploadImage, memberUpdateProfileRequest);
     return ResponseEntity.ok(ResultResponse.of(ResultCode.MEMBER_IMAGEUPDATE_SUCCESS, true));

--- a/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberUpdateController.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/controller/MemberUpdateController.java
@@ -24,8 +24,9 @@ public class MemberUpdateController {
 
   @LoginRequired
   @PostMapping("/update")
-  public ResponseEntity<ResultResponse> updateMember(@RequestParam MultipartFile uploadImage,
-                                                    @RequestBody MemberUpdateProfileRequest memberUpdateProfileRequest) {
+  public ResponseEntity<ResultResponse> updateMember(
+      @RequestPart (value = "image", required = false) MultipartFile uploadImage,
+      @RequestPart (value = "memberUpdateProfileRequest") MemberUpdateProfileRequest memberUpdateProfileRequest) {
     memberUpdateService.updateMemberProfile(uploadImage, memberUpdateProfileRequest);
     return ResponseEntity.ok(ResultResponse.of(ResultCode.MEMBER_IMAGEUPDATE_SUCCESS, true));
   }

--- a/src/main/java/com/sprios/sprios_spring/domain/member/dto/MemberUpdateProfileRequest.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/dto/MemberUpdateProfileRequest.java
@@ -1,0 +1,13 @@
+package com.sprios.sprios_spring.domain.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberUpdateProfileRequest {
+  private String name;
+  private String account;
+  private String introduce;
+}

--- a/src/main/java/com/sprios/sprios_spring/domain/member/entity/Member.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/entity/Member.java
@@ -76,7 +76,7 @@ public class Member extends BaseEntity {
         .imgType(ImageType.PNG)
         .imgUrl(DEFAULT_IMAGE_URL)
         .imgUUID("base-UUID").build();
-    this.introduce = "";
+    this.introduce = introduce;
   }
 
   public void setEncryptedPassword(String encryptedPassword) {

--- a/src/main/java/com/sprios/sprios_spring/domain/member/exception/MemberUpdateFailException.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/exception/MemberUpdateFailException.java
@@ -1,0 +1,11 @@
+package com.sprios.sprios_spring.domain.member.exception;
+
+import com.sprios.sprios_spring.global.error.ErrorCode;
+import com.sprios.sprios_spring.global.error.exception.BusinessException;
+
+public class MemberUpdateFailException extends BusinessException {
+
+  public MemberUpdateFailException() {
+    super(ErrorCode.MEMBER_UPDATE_FAIL);
+  }
+}

--- a/src/main/java/com/sprios/sprios_spring/domain/member/service/MemberUpdateService.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/service/MemberUpdateService.java
@@ -38,6 +38,9 @@ public class MemberUpdateService {
 
   private Image uploadImgS3(MultipartFile file, Image oldImage) {
     s3Uploader.deleteImage(oldImage.getImgName(), MEMBER_S3_DIRNAME);
+    if(file == null) {
+      return ImageUtil.getDefaultImg();
+    }
     String imgUrl = s3Uploader.uploadImage(file, MEMBER_S3_DIRNAME);
     return ImageUtil.convertMultipartFiletoImage(file, imgUrl);
   }

--- a/src/main/java/com/sprios/sprios_spring/domain/member/service/MemberUpdateService.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/service/MemberUpdateService.java
@@ -31,7 +31,7 @@ public class MemberUpdateService {
     final Member member = getLoginMember();
     member.setName(memberUpdateProfileRequest.getName());
     member.setIntroduce(memberUpdateProfileRequest.getIntroduce());
-    member.setAccount(member.getAccount());
+    member.setAccount(memberUpdateProfileRequest.getAccount());
     member.setImage(uploadImgS3(file, member.getImage()));
     memberRepository.save(member);
   }

--- a/src/main/java/com/sprios/sprios_spring/domain/member/service/MemberUpdateService.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/member/service/MemberUpdateService.java
@@ -2,6 +2,7 @@ package com.sprios.sprios_spring.domain.member.service;
 
 
 import com.sprios.sprios_spring.aws.S3Uploader;
+import com.sprios.sprios_spring.domain.member.dto.MemberUpdateProfileRequest;
 import com.sprios.sprios_spring.domain.member.entity.Member;
 import com.sprios.sprios_spring.domain.member.repository.MemberRepository;
 import com.sprios.sprios_spring.global.util.ImageUtil;
@@ -25,14 +26,20 @@ public class MemberUpdateService {
   private static final String MEMBER_ID = "MEMBER_ID";
 
   @Transactional
-  public void uploadImgS3(MultipartFile file) {
+  public void updateMemberProfile(MultipartFile file,
+                                  MemberUpdateProfileRequest memberUpdateProfileRequest) {
     final Member member = getLoginMember();
-    final Image oldImage = member.getImage();
+    member.setName(memberUpdateProfileRequest.getName());
+    member.setIntroduce(memberUpdateProfileRequest.getIntroduce());
+    member.setAccount(member.getAccount());
+    member.setImage(uploadImgS3(file, member.getImage()));
+    memberRepository.save(member);
+  }
+
+  private Image uploadImgS3(MultipartFile file, Image oldImage) {
     s3Uploader.deleteImage(oldImage.getImgName(), MEMBER_S3_DIRNAME);
     String imgUrl = s3Uploader.uploadImage(file, MEMBER_S3_DIRNAME);
-    Image newImage = ImageUtil.convertMultipartFiletoImage(file, imgUrl);
-    member.setImage(newImage);
-    memberRepository.save(member);
+    return ImageUtil.convertMultipartFiletoImage(file, imgUrl);
   }
   private Member getLoginMember() {
     Long memberId = (Long) httpSession.getAttribute(MEMBER_ID);

--- a/src/main/java/com/sprios/sprios_spring/global/error/ErrorCode.java
+++ b/src/main/java/com/sprios/sprios_spring/global/error/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
   MEMBER_NOT_FOUND(400, "M001", "회원 찾기 실패"),
   MEMBER_ACCOUNT_DUPLICATED(400, "M002", "회원 아이디 중복"),
   UN_AUTHORIZED_ACCESS(400, "M003", "승인되지 않은 접근"),
+  MEMBER_UPDATE_FAIL(500, "M004", "회원 정보 갱신 실패"),
 
   // Post
   POST_NOT_FOUND(400, "P001", "게시물 찾기 실패");

--- a/src/main/java/com/sprios/sprios_spring/global/result/ResultCode.java
+++ b/src/main/java/com/sprios/sprios_spring/global/result/ResultCode.java
@@ -15,8 +15,7 @@ public enum ResultCode {
   MEMBER_ACCOUNT_NOT_DUPLICATED("M003", "회원 아이디 중복되지않음"),
   MEMBER_LOGIN_SUCCESS("M004", "회원 로그인 성공"),
   MEMBER_LOGOUT_SUCCESS("M005", "회원 로그아웃 성공"),
-  MEMBER_IMAGEUPDATE_SUCCESS("M006", "프로필 이미지 변경 성공"),
-  MEMBER_UPDATE_SUCCESS("M007", "회원 정보 수정 성공"),
+  MEMBER_UPDATE_SUCCESS("M006", "회원 프로필 업데이트 성공"),
 
   // Post
   POST_CREATE_SUCCESS("P001", "게시물 생성 성공"),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43312015/209397018-be695513-b901-40ab-b6e1-ec1415170848.png)
기존에 이미지만 단독으로 업데이트 하던 컨트롤러 수정해서 프로필 업데이트 API로 변경했습니다.

![image](https://user-images.githubusercontent.com/43312015/209398860-d0ba7035-d424-4ef2-afef-ca7cc5eeedee.png)
(변경 전)

![image](https://user-images.githubusercontent.com/43312015/209398918-7d2f0fe2-44dd-4cdb-9c58-75fcb1c05f94.png)
![image](https://user-images.githubusercontent.com/43312015/209399206-f0438001-01cf-4abc-b63e-059daa4b1bb8.png)
(변경 후)

![image](https://user-images.githubusercontent.com/43312015/209399251-ec307d3e-7657-4b85-a463-c5a371bb7dd6.png)
(프로필 이미지 없이 변경)
![image](https://user-images.githubusercontent.com/43312015/209399301-cf50f773-cd7d-4d77-94ef-93285229b6d4.png)
(다시 변경 후)