### PR TITLE
[fix] 회원별 게시물 조회시 최신순으로 정렬하도록 수정

### DIFF
--- a/src/main/java/com/sprios/sprios_spring/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/post/repository/PostRepository.java
@@ -1,11 +1,12 @@
 package com.sprios.sprios_spring.domain.post.repository;
 
 import com.sprios.sprios_spring.domain.post.entity.Post;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-    Optional<List<Post>> findAllByWriterId(Long writerId);
+    Optional<List<Post>> findAllByWriterId(Long writerId, Sort sort);
 }

--- a/src/main/java/com/sprios/sprios_spring/domain/post/service/PostService.java
+++ b/src/main/java/com/sprios/sprios_spring/domain/post/service/PostService.java
@@ -17,6 +17,7 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -48,7 +49,9 @@ public class PostService {
 
   public List<PostInfoResponse> getPostListByWriterId(Long writerId) {
     List<Post> posts =
-        postRepository.findAllByWriterId(writerId).orElseThrow(MemberNotFoundException::new);
+        postRepository
+            .findAllByWriterId(writerId, Sort.by("id").descending())
+            .orElseThrow(MemberNotFoundException::new);
     return postMapper.toDtoList(posts);
   }
 


### PR DESCRIPTION
회원별 게시물 조회시 최신순으로 정렬하도록 수정
<img width="520" alt="image" src="https://user-images.githubusercontent.com/108508730/209677664-a777333f-3489-49b9-8945-6a15df78c3ee.png">